### PR TITLE
cache first version for legacy versions (backport: #1018)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#961](https://github.com/cosmos/iavl/pull/961) Add new `GetLatestVersion` API to get the latest version.
 - [#965](https://github.com/cosmos/iavl/pull/965) Use expected interface for expected IAVL `Logger`.
 - [#970](https://github.com/cosmos/iavl/pull/970) Close the pruning process when the nodeDB is closed.
+- [#1018](https://github.com/cosmos/iavl/pull/1018) Cache first version for legacy versions, fix performance regression after upgrade.
 
 ## v1.2.0 May 13, 2024
 

--- a/nodedb.go
+++ b/nodedb.go
@@ -726,6 +726,7 @@ func (ndb *nodeDB) getFirstVersion() (int64, error) {
 	if itr.Valid() {
 		var version int64
 		legacyRootKeyFormat.Scan(itr.Key(), &version)
+		ndb.resetFirstVersion(version)
 		return version, nil
 	}
 	// Find the first version


### PR DESCRIPTION
changelog